### PR TITLE
Final Deletrathol tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -341,7 +341,8 @@
 	taste_description = "confusion"
 	color = "#800080"
 	reagent_state = LIQUID
-	overdose = 15
+	overdose = 10
+	metabolism = 0.02
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 


### PR DESCRIPTION
After discussion with other players; restored Delet's ultraslow metabolism but lowered OD to 10.
Given metabolism of 0.02 and how Delet is currently coded; a full dose of 10 should provide maximal painkilling for 250 ticks.

