### PR TITLE
Fixes

### DIFF
--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -45,7 +45,7 @@
 	light(0)
 
 /obj/item/clothing/mask/smokable/proc/smoke(amount)
-	smoketime -= amount
+	smoketime = max(smoketime - amount, 0.5)
 	if(reagents && reagents.total_volume) // check if it has any reagents at all
 		var/consumption_rate = reagents.total_volume / smoketime
 		if(ishuman(loc))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -140,22 +140,22 @@
 		strength_mod = 0
 
 	affected.add_chemical_effect(CE_ALCOHOL, 1)
-	affected.add_chemical_effect(CE_PAINKILLER, clamp(round((dose/10) * 10, 1), 1, 80))
+	affected.add_chemical_effect(CE_PAINKILLER, clamp(round(dose, 1), 1, 80))
 	var/effective_dose = dose * strength_mod
 
-	if (effective_dose >= 15)
+	if (prob(effective_dose*2))
 		affected.make_dizzy(6)
-	if (effective_dose >= 30)
+	if (effective_dose >= 0.5 * overdose)
 		affected.slurring = max(affected.slurring, 30)
 		affected.add_chemical_effect(CE_ALCOHOL, 1)
-	if (effective_dose >= 45)
+	if (effective_dose >= 0.75 * overdose)
 		affected.set_confused(20)
 		affected.add_chemical_effect(CE_ALCOHOL, 1)
-	if (effective_dose >= 60)
+	if (effective_dose >= overdose)
 		affected.eye_blurry = max(affected.eye_blurry, 10)
 		affected.drowsyness = max(affected.drowsyness, 20)
 		affected.add_chemical_effect(CE_ALCOHOL_TOXIC, clamp(round(dose/60, 1), 1, 8))
-	if (effective_dose >= 90)
+	if (effective_dose >= 1.5 * overdose)
 		affected.Paralyse(20)
 		affected.Sleeping(30)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
@@ -59,7 +59,7 @@
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
 	taste_description = "piss water"
 	color = "#ffd300"
-	metabolite_potency = 0.6
+	metabolite_potency = 0.4
 	nutriment_factor = 4
 
 	glass_name = "beer"
@@ -68,7 +68,7 @@
 /datum/reagent/ethanol/beer/good
 
 	taste_description = "beer"
-	metabolite_potency = 0.5
+	metabolite_potency = 0.3
 
 /datum/reagent/ethanol/beer/affect_ingest(mob/living/carbon/M, removed)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -265,28 +265,28 @@
 	taste_description = "generic sourness"
 	reagent_state = LIQUID
 	color = "#7b23a4"
-	overdose = 30
+	overdose = 60
 	scannable = TRUE
-	metabolism = 0.05
+	metabolism = 0.1
 	active_metabolites = /datum/reagent/opiate
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/opiate/affect_metabolites(mob/living/carbon/affected, dose)
-	var/pain_effect = 10 * dose
+	var/pain_effect = 5 * dose
 	var/hallucination_chance = 0
 	affected.add_chemical_effect(CE_PAINKILLER, pain_effect)
 
-	if (dose > 0.25 * overdose)
+	if (dose >= 0.25 * overdose)
 		affected.add_chemical_effect(CE_SLOWDOWN, 1)
-	if (dose > 0.5 * overdose)
+	if (dose >= 0.5 * overdose)
 		affected.add_chemical_effect(CE_SLOWDOWN, 1)
 		if (prob(1))
 			affected.slurring = max(affected.slurring, 10)
-	if (dose > 0.75 * overdose)
+	if (dose >= 0.75 * overdose)
 		affected.add_chemical_effect(CE_SLOWDOWN, 1)
 		if (prob(10))
 			affected.slurring = max(affected.slurring, 20)
-	if (dose > overdose)
+	if (dose >= overdose)
 		affected.add_chemical_effect(CE_PAINKILLER, dose*0.5)
 		hallucination_chance += dose/3
 


### PR DESCRIPTION
- Fixes another div by 0 bug
- No idea what I was thinking when I made alcohol's pain effect be dose multiplied by 10 then divided by 10. Brilliance!
- Made alcohol effects thresholds be a multiple of OD for easier maintainability.
- Dizziness is now prob based; not a guarantee at 15. Should happen less frequently.
- Tweaks beer metabolite number; good beer now needs 200 units consumed straight with no break to OD, bad beer 150. About 60% more beer than test merged numbers.
