### PR TITLE
Tweaks opiate slowdown, adds naloxone

### DIFF
--- a/code/game/machinery/vending/wallmed1.dm
+++ b/code/game/machinery/vending/wallmed1.dm
@@ -24,6 +24,7 @@
 		/obj/item/stack/medical/ointment = 3,
 		/obj/item/reagent_containers/pill/paracetamol = 4,
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy = 3,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/naloxone = 3,
 		/obj/item/storage/med_pouch/trauma,
 		/obj/item/storage/med_pouch/burn,
 		/obj/item/storage/med_pouch/oxyloss,

--- a/code/game/machinery/vending/wallmed2.dm
+++ b/code/game/machinery/vending/wallmed2.dm
@@ -22,6 +22,7 @@
 	products = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 5,
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy = 4,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/naloxone = 4,
 		/obj/item/stack/medical/bruise_pack = 4,
 		/obj/item/stack/medical/ointment = 4,
 		/obj/item/storage/med_pouch/trauma,

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -554,3 +554,8 @@
 
 /mob/living/carbon/proc/vomit(timevomit = 1, level = 3, delay = 0)
 	return
+
+/mob/living/carbon/proc/is_fast()
+	if (bloodstr.has_reagent(/datum/reagent/hyperzine) || metabolized.has_reagent(/datum/reagent/hyperzine))
+		return TRUE
+	else return FALSE

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
@@ -1515,22 +1515,24 @@
 
 /datum/reagent/ethanol/qokkloa/affect_ingest(mob/living/carbon/M, removed)
 	..()
-	if (ishuman(M))
-		M.adjustToxLoss(5 * removed)
-	if (M.chem_effects[CE_ALCOHOL] > 1 && ishuman(M))
+	if (!ishuman(M) || HAS_TRAIT(M, /singleton/trait/boon/clear_mind))
+		return
+	M.adjustToxLoss(5 * removed)
+	if (M.chem_effects[CE_ALCOHOL] > 1)
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/L = H.internal_organs_by_name[BP_HEART]
 		if (istype(L))
 			L.take_internal_damage(M.chem_effects[CE_ALCOHOL_TOXIC] * removed, 0)
 			M.adjustToxLoss(5 * M.chem_effects[CE_ALCOHOL_TOXIC] * removed)
 
-/datum/reagent/ethanol/qokkhrona
+/datum/reagent/ethanol/qokkloa/qokkhrona
 	name = "Qokk'hrona"
 	description = "Delicious Skrellian wine from refined qokk'loa."
 	taste_description = "a thick potion of mushroom, slime, and hard alcohol"
 	color = "#c76c4d"
 	metabolite_potency = 0.05
 	druggy = 5
+	halluci = 0
 
 	glass_name = "qokk'hrona"
 	glass_desc = "Delicious Skrellian wine from refined qokk'loa."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -272,20 +272,20 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/opiate/affect_metabolites(mob/living/carbon/affected, dose)
+	if (!istype(affected))
+		return
 	var/pain_effect = 5 * dose
 	var/hallucination_chance = 0
 	affected.add_chemical_effect(CE_PAINKILLER, pain_effect)
 
-	if (dose >= 0.25 * overdose)
-		affected.add_chemical_effect(CE_SLOWDOWN, 1)
+	if ((dose >= 0.25 * overdose) && prob(1))
+		affected.slurring = max(affected.slurring, 10)
 	if (dose >= 0.5 * overdose)
-		affected.add_chemical_effect(CE_SLOWDOWN, 1)
-		if (prob(1))
-			affected.slurring = max(affected.slurring, 10)
-	if (dose >= 0.75 * overdose)
 		affected.add_chemical_effect(CE_SLOWDOWN, 1)
 		if (prob(10))
 			affected.slurring = max(affected.slurring, 20)
+	if (dose >= 0.75 * overdose)
+		affected.add_chemical_effect(CE_SLOWDOWN, 1)
 	if (dose >= overdose)
 		affected.add_chemical_effect(CE_PAINKILLER, dose*0.5)
 		hallucination_chance += dose/3
@@ -295,7 +295,7 @@
 		affected.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
 		affected.add_chemical_effect(CE_BREATHLOSS, 0.1 * boozed) //drinking and opiating makes breathing kinda hard
 		hallucination_chance *= 1.2
-	if(isfast(affected))
+	if(affected.is_fast())
 		affected.add_chemical_effect(CE_BREATHLOSS, 0.5)
 		affected.add_chemical_effect(CE_SLOWDOWN, 2) //hyperzine reacts negatively with opiates
 		hallucination_chance *= 1.5
@@ -305,19 +305,16 @@
 		affected.hallucination(60, 30)
 
 /datum/reagent/opiate/process_overdose(mob/living/carbon/M)
+	if (!istype(M))
+		return
 	M.druggy = max(M.druggy, 10)
 	M.add_chemical_effect(CE_BREATHLOSS, 0.6) //Have trouble breathing, need more air
 	if(M.chem_effects[CE_ALCOHOL])
 		M.add_chemical_effect(CE_BREATHLOSS, 0.2) //Don't drink and OD on opiates folks
-	if(isfast(M))
+	if(M.is_fast())
 		M.add_chemical_effect(CE_NOPULSE, 1)
 		var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART] //heart damage + arrest
 		heart.take_internal_damage(heart.max_damage * 0.045)
-
-/datum/reagent/opiate/proc/isfast(mob/living/carbon/M)
-	if (M.bloodstr.has_reagent(/datum/reagent/hyperzine) || M.metabolized.has_reagent(/datum/reagent/hyperzine))
-		return TRUE
-	else return FALSE
 
 /datum/reagent/opiate/tramadol
 	name = "Tramadol"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2893,7 +2893,7 @@
 
 /singleton/reaction/qokkhrona
 	name = "Qokk'Hrona"
-	result = /datum/reagent/ethanol/qokkhrona
+	result = /datum/reagent/ethanol/qokkloa/qokkhrona
 	required_reagents = list(/datum/reagent/ethanol/qokkloa = 2, /datum/reagent/ethanol/wine = 1)
 	catalysts = list(/datum/reagent/enzyme = 5)
 	result_amount = 3

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -101,7 +101,7 @@ var/global/list/lunchables_ethanol_reagents_ = list(
 												/datum/reagent/ethanol/threemileisland,
 												/datum/reagent/ethanol/toxins_special,
 												/datum/reagent/ethanol/qokkloa,
-												/datum/reagent/ethanol/qokkhrona,
+												/datum/reagent/ethanol/qokkloa/qokkhrona,
 												/datum/reagent/ethanol/iridast
 											)
 


### PR DESCRIPTION
Adds naloxone to wallmeds.
Tweaks opiate side effects; now slowdown only kicks in at 50% of OD. To have some side effects; moved down slurring to occur earlier.

Would wait before merging pending feedback from the skrell alcohol issue which I'll fix in this PR.